### PR TITLE
boyscout: remove app tier log statement

### DIFF
--- a/cli-checks-from-json/src/__checks__/dynamic-json.check.ts
+++ b/cli-checks-from-json/src/__checks__/dynamic-json.check.ts
@@ -23,7 +23,6 @@ apps.forEach((app: any) => {
 
   // Read through new tier based categories
   ['app4', 'app3', 'app2', 'app1'].forEach((tier) => {
-    console.log(tier, 'tier');
     if (app[tier].length >= 1) {
       const group = createGroup(app.appName, tier);
 


### PR DESCRIPTION
@modern-sapien I don't think the log statement on app tier is needed, shall we clean it up?